### PR TITLE
🐛 [BugFix] scrap list 조회시 500 error 해결

### DIFF
--- a/src/main/java/com/juju/cozyformombackend3/domain/communitylog/cozylog/service/CozyLogService.java
+++ b/src/main/java/com/juju/cozyformombackend3/domain/communitylog/cozylog/service/CozyLogService.java
@@ -55,6 +55,7 @@ public class CozyLogService {
     @Transactional
     public Long deleteCozyLog(Long userId, Long removeCozyLogId) {
         cozyLogRepository.deleteById(removeCozyLogId);
+        scrapRepository.deleteAllByCozyLogId(removeCozyLogId);
 
         return removeCozyLogId;
     }
@@ -108,7 +109,7 @@ public class CozyLogService {
     public void deleteCozyLogList(Long userId, DeleteMyCozyLogListRequest request) {
         cozyLogRepository.deleteCozyLogByUserIdAndCozyLogIds(userId, request.getCozyLogIds());
     }
-    
+
     public SearchCozyLogResponse searchCozyLog(final CozyLogCondition condition) {
         List<CozyLogSummary> cozyLogs = cozyLogRepository.searchCozyLogListByCondition(condition);
         Long totalCount = cozyLogRepository.countByCondition(condition);

--- a/src/main/java/com/juju/cozyformombackend3/domain/communitylog/scrap/repository/CustomScrapRepositoryImpl.java
+++ b/src/main/java/com/juju/cozyformombackend3/domain/communitylog/scrap/repository/CustomScrapRepositoryImpl.java
@@ -41,7 +41,8 @@ public class CustomScrapRepositoryImpl implements CustomScrapRepository {
                 cozyLogImage.imageUrl.coalesce(""), cozyLog.cozyLogImageList.size()))
             .from(scrap)
             .leftJoin(cozyLog).on(cozyLog.id.eq(scrap.cozyLogId))
-            .leftJoin(comment).on(comment.cozyLog.id.eq(cozyLog.id))
+            .leftJoin(comment).on(comment.cozyLog.id.eq(cozyLog.id)
+                .and(comment.isDeleted.eq(false)))
             .leftJoin(cozyLogImage).on(cozyLogImage.id.eq(firstImageSubQuery))
             .where(scrap.user.id.eq(userId).and(ltReportId(reportId)))
             .groupBy(cozyLog.id, cozyLog.title, cozyLog.content, cozyLog.createdAt, cozyLog.mode,

--- a/src/main/java/com/juju/cozyformombackend3/domain/communitylog/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/juju/cozyformombackend3/domain/communitylog/scrap/repository/ScrapRepository.java
@@ -7,11 +7,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.juju.cozyformombackend3.domain.communitylog.scrap.model.Scrap;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long>, CustomScrapRepository {
-	Long countByCozyLogId(Long cozyLogId);
+    Long countByCozyLogId(Long cozyLogId);
 
-	boolean existsByCozyLogIdAndUserId(Long cozyLogId, Long userId);
+    boolean existsByCozyLogIdAndUserId(Long cozyLogId, Long userId);
 
-	Optional<Scrap> findByCozyLogIdAndUserId(Long cozyLogId, Long userId);
+    Optional<Scrap> findByCozyLogIdAndUserId(Long cozyLogId, Long userId);
 
-	Long countByUserId(Long userId);
+    Long countByUserId(Long userId);
+
+    void deleteAllByCozyLogId(Long removeCozyLogId);
 }


### PR DESCRIPTION
- closes: #140 

스크랩 table에 삭제된 cozylog의 id가 남아있어 발생한 에러
코지로그를 삭제할 때 scrap에서도 삭제하도록 수정함. 