### PR TITLE
fix: 기간별 혈당 조회 where 조건에 userId, order 추가

### DIFF
--- a/src/main/java/com/juju/cozyformombackend3/domain/userlog/bloodsugar/repository/CustomBloodSugarRepositoryImpl.java
+++ b/src/main/java/com/juju/cozyformombackend3/domain/userlog/bloodsugar/repository/CustomBloodSugarRepositoryImpl.java
@@ -1,18 +1,17 @@
 package com.juju.cozyformombackend3.domain.userlog.bloodsugar.repository;
 
-import static com.juju.cozyformombackend3.domain.userlog.bloodsugar.model.QBloodSugarRecord.*;
-
-import java.time.LocalDate;
-import java.util.List;
-
 import com.juju.cozyformombackend3.domain.userlog.bloodsugar.dto.object.FindDaliyBloodSugar;
 import com.juju.cozyformombackend3.domain.userlog.bloodsugar.dto.object.FindPeriodicBloodSugar;
 import com.juju.cozyformombackend3.domain.userlog.bloodsugar.dto.object.QFindDaliyBloodSugar;
 import com.juju.cozyformombackend3.domain.userlog.bloodsugar.dto.object.QFindPeriodicBloodSugar;
 import com.juju.cozyformombackend3.global.dto.request.FindPeriodRecordCondition;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.juju.cozyformombackend3.domain.userlog.bloodsugar.model.QBloodSugarRecord.bloodSugarRecord;
 
 @RequiredArgsConstructor
 public class CustomBloodSugarRepositoryImpl implements CustomBloodSugarRepository {
@@ -22,13 +21,13 @@ public class CustomBloodSugarRepositoryImpl implements CustomBloodSugarRepositor
     @Override
     public List<FindDaliyBloodSugar> searchAllByRecordAt(Long userId, LocalDate recordAt) {
         return jpaQueryFactory
-            .select(new QFindDaliyBloodSugar(bloodSugarRecord.id, bloodSugarRecord.bloodSugarRecordType,
-                bloodSugarRecord.level))
-            .from(bloodSugarRecord)
-            .where(bloodSugarRecord.user.id.eq(userId),
-                bloodSugarRecord.recordAt.eq(recordAt))
-            .orderBy(bloodSugarRecord.recordAt.asc())
-            .fetch();
+                .select(new QFindDaliyBloodSugar(bloodSugarRecord.id, bloodSugarRecord.bloodSugarRecordType,
+                        bloodSugarRecord.level))
+                .from(bloodSugarRecord)
+                .where(bloodSugarRecord.user.id.eq(userId),
+                        bloodSugarRecord.recordAt.eq(recordAt))
+                .orderBy(bloodSugarRecord.recordAt.asc())
+                .fetch();
     }
 
     @Override
@@ -37,50 +36,45 @@ public class CustomBloodSugarRepositoryImpl implements CustomBloodSugarRepositor
         Long size = condition.getSize();
 
         return switch (condition.getType()) {
-            case MONTHLY -> findMonthlyRecordByDate(endDate, size);
-            case WEEKLY -> findWeeklyRecordByDate(endDate, size);
-            default -> findDailyRecordByDate(endDate, size);
+            case MONTHLY -> findMonthlyRecordByDate(condition.getUserId(), endDate, size);
+            case WEEKLY -> findWeeklyRecordByDate(condition.getUserId(), endDate, size);
+            default -> findDailyRecordByDate(condition.getUserId(), endDate, size);
         };
     }
 
-    private List<FindPeriodicBloodSugar> findMonthlyRecordByDate(LocalDate endDate, Long size) {
+    private List<FindPeriodicBloodSugar> findMonthlyRecordByDate(Long userId, LocalDate endDate, Long size) {
         return jpaQueryFactory.select(new QFindPeriodicBloodSugar(
-                bloodSugarRecord.recordAt.stringValue(),
-                bloodSugarRecord.level.avg()))
-            .from(bloodSugarRecord)
-            .where(bloodSugarRecord.recordAt
-                .between(endDate.minusMonths(size).withDayOfMonth(1), endDate))
-            .groupBy(bloodSugarRecord.recordAt.month())
-            .fetch();
+                        bloodSugarRecord.recordAt.stringValue(),
+                        bloodSugarRecord.level.avg()))
+                .from(bloodSugarRecord)
+                .where(bloodSugarRecord.user.id.eq(userId),
+                        bloodSugarRecord.recordAt.between(endDate.minusMonths(size).withDayOfMonth(1), endDate))
+                .groupBy(bloodSugarRecord.recordAt.month())
+                .orderBy(bloodSugarRecord.recordAt.desc())
+                .fetch();
     }
 
-    private List<FindPeriodicBloodSugar> findWeeklyRecordByDate(LocalDate endDate, Long size) {
+    private List<FindPeriodicBloodSugar> findWeeklyRecordByDate(Long userId, LocalDate endDate, Long size) {
         return jpaQueryFactory.select(new QFindPeriodicBloodSugar(
-                bloodSugarRecord.recordAt.stringValue(),
-                bloodSugarRecord.level.avg()))
-            .from(bloodSugarRecord)
-            .where(bloodSugarRecord.recordAt
-                .between(endDate.minusWeeks(size), endDate))
-            .groupBy(bloodSugarRecord.recordAt.week())
-            .fetch();
+                        bloodSugarRecord.recordAt.stringValue(),
+                        bloodSugarRecord.level.avg()))
+                .from(bloodSugarRecord)
+                .where(bloodSugarRecord.user.id.eq(userId),
+                        bloodSugarRecord.recordAt.between(endDate.minusWeeks(size), endDate))
+                .groupBy(bloodSugarRecord.recordAt.week())
+                .orderBy(bloodSugarRecord.recordAt.desc())
+                .fetch();
     }
 
-    private List<FindPeriodicBloodSugar> findDailyRecordByDate(LocalDate endDate, Long size) {
+    private List<FindPeriodicBloodSugar> findDailyRecordByDate(Long userId, LocalDate endDate, Long size) {
         return jpaQueryFactory.select(new QFindPeriodicBloodSugar(
-                bloodSugarRecord.recordAt.stringValue(),
-                bloodSugarRecord.level.avg()))
-            .from(bloodSugarRecord)
-            .where(bloodSugarRecord.recordAt
-                .between(endDate.minusDays(size), endDate))
-            .groupBy(bloodSugarRecord.recordAt)
-            .fetch();
-    }
-
-    private boolean hasNextPage(List<FindPeriodicBloodSugar> data, int pageSize) {
-        if (data.size() > pageSize) {
-            data.remove(pageSize);
-            return true;
-        }
-        return false;
+                        bloodSugarRecord.recordAt.stringValue(),
+                        bloodSugarRecord.level.avg()))
+                .from(bloodSugarRecord)
+                .where(bloodSugarRecord.user.id.eq(userId),
+                        bloodSugarRecord.recordAt.between(endDate.minusDays(size), endDate))
+                .groupBy(bloodSugarRecord.recordAt)
+                .orderBy(bloodSugarRecord.recordAt.desc())
+                .fetch();
     }
 }


### PR DESCRIPTION
- 혈당 기간별 조회에서 다른 사람 기록을 가져오고 정렬안되는 버그 발생
-> where 조건에 userId, order 가 누락되어 추가하여 해결
---
- closes: #228